### PR TITLE
feat: add dashboard port increment

### DIFF
--- a/backend/cmd/dash.go
+++ b/backend/cmd/dash.go
@@ -142,7 +142,7 @@ func handleClusterVisualizationRequest(w http.ResponseWriter, r *http.Request) {
 
 func getNextAvailablePort(startPort string) string {
     port := startPort
-    for {
+    for i:=0; i<10; i++ {
         socket := net.JoinHostPort("localhost", port)
         _, err := net.Dial("tcp", socket)
         if err != nil {
@@ -156,4 +156,6 @@ func getNextAvailablePort(startPort string) string {
             }
         }
     }
+    log.Fatalf("Unable to find an available port between %v and %v", startPort, port)
+    return ""
 }

--- a/backend/cmd/dash.go
+++ b/backend/cmd/dash.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+    "net"
+    "strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -63,7 +65,7 @@ func startDashboardServer() {
 	handler := c.Handler(http.DefaultServeMux)
 
 	// Start the server
-	port := "8080"
+	port := getNextAvailablePort("8080")
 	fmt.Printf("Starting dashboard server on http://localhost:%s\n", port)
 	if err := http.ListenAndServe(":"+port, handler); err != nil {
 		log.Fatalf("Failed to start server: %v\n", err)
@@ -136,4 +138,18 @@ func handleClusterVisualizationRequest(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(clusterVizData); err != nil {
 		http.Error(w, "Failed to encode cluster visualization data", http.StatusInternalServerError)
 	}
+}
+
+func getNextAvailablePort(startPort string) string {
+    port := startPort
+    for {
+        socket := net.JoinHostPort("localhost", port)
+        _, err := net.Dial("tcp", socket)
+        if err != nil {
+            return port
+        } else {
+            int, _ := strconv.Atoi(port)
+            port = strconv.Itoa(int + 1)
+        }
+    }
 }

--- a/backend/cmd/dash.go
+++ b/backend/cmd/dash.go
@@ -148,8 +148,12 @@ func getNextAvailablePort(startPort string) string {
         if err != nil {
             return port
         } else {
-            int, _ := strconv.Atoi(port)
-            port = strconv.Itoa(int + 1)
+            int, err := strconv.Atoi(port)
+            if err != nil {
+                log.Fatalf("Failed to convert port to string: %v\n", err)
+            } else {
+                port = strconv.Itoa(int + 1)
+            }
         }
     }
 }


### PR DESCRIPTION
Added function to find the next available port when running the dashboard. It'll start at 8080 and increment up by 1 until an unused port is found.

Proposed as a solution to #8.

![image](https://github.com/deggja/netfetch/assets/25581895/30e8d298-d9d6-43c9-ba49-9dbccfe21ca1)
