### PR TITLE
feat: update hbformula, goreleaser for changelog and dynamic versioning #patch

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,23 @@
 # .goreleaser.yml
 project_name: netfetch
 
+changelog:
+  sort: desc
+  filters:
+    exclude:
+      - '^Merge pull request'
+      - '^chore:'
+      - '^refactor:'
+      - '^style:'
+      - '^test:'
+  groups:
+    - title: "Features"
+      regexp: "^feat:"
+    - title: "Bug Fixes"
+      regexp: "^fix:"
+    - title: "Documentation Updates"
+      regexp: "^docs:"
+
 # Build configuration
 builds:
   - id: "netfetch"
@@ -13,6 +30,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w -X 'github.com/deggja/netfetch/backend/cmd.Version={{.Version}}'
     # Additional build flags can be added here
 
 # Archive configuration

--- a/netfetch.rb
+++ b/netfetch.rb
@@ -15,6 +15,6 @@ class Netfetch < Formula
   end
 
   test do
-    system "#{bin}/netfetch", "--version"
+    system "#{bin}/netfetch", "version"
   end
 end


### PR DESCRIPTION
Update the homebrew formula to run the netfetch version command instead of netfetch --version. Update goreleaser to style changelog in releases + utilise version variable in application version.