### PR TITLE
feat: added tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,28 @@ brew cleanup -s netfetch
 brew untap deggja/netfetch https://github.com/deggja/netfetch
 ```
 
+## Running Tests
+
+To run tests for this project, follow these steps:
+
+1. Navigate to the root directory of the project in your terminal.
+
+2. Navigate to the backend directory within the project:
+
+```
+cd backend
+```
+
+3. Run the following command to execute all tests in the project:
+
+```
+go test ./...
+```
+
+This command will recursively search for tests in all subdirectories (./...) and run them.
+
+4. After executing the command, you will see the test results in the terminal output.
+
 ## Contribute 🔨
 Thank you to the following awesome people:
 

--- a/backend/cmd/dash.go
+++ b/backend/cmd/dash.go
@@ -130,7 +130,13 @@ func handleNamespacesWithPoliciesRequest(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	namespaces, err := k8s.GatherNamespacesWithPolicies()
+	clientset, err := k8s.GetClientset()
+	if err != nil {
+		log.Fatalf("You are not connected to a Kubernetes cluster. Please connect to a cluster and re-run the command: %v", err)
+		return
+	}
+
+	namespaces, err := k8s.GatherNamespacesWithPolicies(clientset)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -188,8 +194,15 @@ func handleClusterVisualizationRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+
+	clientset, err := k8s.GetClientset()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	// Call the function to gather cluster-wide visualization data
-	clusterVizData, err := k8s.GatherClusterVisualizationData()
+	clusterVizData, err := k8s.GatherClusterVisualizationData(clientset)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -21,7 +21,10 @@ require (
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 )
 
 require (

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -116,6 +116,7 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -124,6 +125,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -15,6 +15,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
 github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -94,6 +96,8 @@ github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=
 github.com/onsi/ginkgo/v2 v2.9.4/go.mod h1:gCQYp2Q+kSoIj7ykSVb9nskRSsR6PUj4AiLywzIhbKM=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=

--- a/backend/pkg/k8s/cilium-scanner_test.go
+++ b/backend/pkg/k8s/cilium-scanner_test.go
@@ -1,0 +1,248 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestMatchesLabels(t *testing.T) {
+	tests := []struct {
+		name          string
+		podLabels     map[string]string
+		policyLabels  map[string]interface{}
+		expectedMatch bool
+	}{
+		{
+			name: "Matching labels",
+			podLabels: map[string]string{
+				"app": "test",
+			},
+			// Equivalent to MatchLabels in a NetworkPolicy object
+			policyLabels: map[string]interface{}{
+				"app": "test",
+			},
+			expectedMatch: true,
+		},
+		{
+			name: "Matching labels",
+			podLabels: map[string]string{
+				"app": "test",
+			},
+			// Equivalent to MatchLabels in a NetworkPolicy object
+			policyLabels: map[string]interface{}{
+				"app": "test-policy",
+			},
+			expectedMatch: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			match := MatchesLabels(test.podLabels, test.policyLabels)
+			// if match != test.expectedMatch {
+			// 	t.Errorf("Expected match: %v, got: %v", test.expectedMatch, match)
+			// }
+			assert.Equal(t, test.expectedMatch, match, "they should be equal")
+		})
+	}
+}
+
+func TestConvertEndpointToSelector(t *testing.T) {
+	tests := []struct {
+		name              string
+		endpointSelector  map[string]interface{}
+		expectedSelector  string
+		expectedError     error
+	}{
+		{
+			name: "Non-Empty Selector",
+			endpointSelector: map[string]interface{}{
+				"matchLabels": map[string]interface{}{"app": "test"},
+			},
+			expectedSelector: "app=test",
+			expectedError: nil,
+		},
+		{
+			name: "Empty Selector",
+			endpointSelector: map[string]interface{}{
+				"matchLabels": map[string]string{},
+			},
+			expectedSelector: "",
+			expectedError:    nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			selector, err := ConvertEndpointToSelector(test.endpointSelector)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			assert.Equal(t, test.expectedSelector, selector)
+		})
+	}
+}
+
+func TestIsDefaultDenyAllCiliumClusterwidePolicy(t *testing.T) {
+	tests := []struct {
+		name               string
+		policyUnstructured unstructured.Unstructured
+		expectedDenyAll    bool
+		expectedCluster    bool
+	}{
+		{
+			name: "Default Deny All Policy",
+			policyUnstructured: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"ingress": []interface{}{},
+						"egress":  []interface{}{},
+						"endpointSelector": map[string]interface{}{
+							"matchLabels": map[string]interface{}{},
+						},
+					},
+				},
+			},
+			expectedDenyAll: true,
+			expectedCluster: true,
+		},
+		{
+			name: "Non-Default Policy",
+			policyUnstructured: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"ingress": []interface{}{
+							map[string]interface{}{
+								"port": 80,
+							}},
+						"egress":  []interface{}{},
+						"endpointSelector": map[string]interface{}{
+							"matchLabels": map[string]interface{}{"app": "test"},
+						},
+					},
+				},
+			},
+			expectedDenyAll: false,
+			expectedCluster: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			denyAll, cluster := IsDefaultDenyAllCiliumClusterwidePolicy(test.policyUnstructured)
+
+			if denyAll != test.expectedDenyAll {
+				t.Errorf("Expected Default Deny All: %v, got: %v", test.expectedDenyAll, denyAll)
+			}
+
+			if cluster != test.expectedCluster {
+				t.Errorf("Expected Clusterwide: %v, got: %v", test.expectedCluster, cluster)
+			}
+		})
+	}
+}
+
+func TestIsEmptyOrOnlyContainsEmptyObjects(t *testing.T) {
+	tests := []struct {
+		name          string
+		slice         []interface{}
+		expectedEmpty bool
+	}{
+		{
+			name:          "Empty Slice",
+			slice:         []interface{}{},
+			expectedEmpty: true,
+		},
+		{
+			name:          "Non-Empty Slice",
+			slice:         []interface{}{map[string]interface{}{"key": "value"}},
+			expectedEmpty: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isEmpty := IsEmptyOrOnlyContainsEmptyObjects(test.slice)
+
+			if isEmpty != test.expectedEmpty {
+				t.Errorf("Expected empty: %v, got: %v", test.expectedEmpty, isEmpty)
+			}
+		})
+	}
+}
+
+func TestIsEndpointSelectorEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		selector map[string]interface{}
+		expectedIsEmpty bool
+	}{
+		{
+			name: "Empty Selector",
+			selector: map[string]interface{}{},
+			expectedIsEmpty: true,
+		},
+		{
+			name: "Non-Empty Selector",
+			selector: map[string]interface{}{
+				"matchLabels": map[string]interface{}{"app": "test"},
+			},
+			expectedIsEmpty: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isEmpty := isEndpointSelectorEmpty(test.selector)
+
+			if isEmpty != test.expectedIsEmpty {
+				t.Errorf("Expected is empty: %v, got: %v", test.expectedIsEmpty, isEmpty)
+			}
+		})
+	}
+}
+
+func TestIsDefaultDenyAllCiliumPolicy(t *testing.T) {
+	tests := []struct {
+		name               string
+		policyUnstructured unstructured.Unstructured
+		expectedDenyAll    bool
+	}{
+		{
+			name: "Default Deny All Policy",
+			policyUnstructured: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"ingress": []interface{}{},
+						"egress":  []interface{}{},
+					},
+				},
+			},
+			expectedDenyAll: true,
+		},
+		{
+			name: "Non-Default Policy",
+			policyUnstructured: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"ingress": []interface{}{map[string]interface{}{"port": 80}},
+						"egress":  []interface{}{},
+					},
+				},
+			},
+			expectedDenyAll: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			denyAll := IsDefaultDenyAllCiliumPolicy(test.policyUnstructured)
+
+			if denyAll != test.expectedDenyAll {
+				t.Errorf("Expected Default Deny All: %v, got: %v", test.expectedDenyAll, denyAll)
+			}
+		})
+	}
+}

--- a/backend/pkg/k8s/scanner.go
+++ b/backend/pkg/k8s/scanner.go
@@ -518,7 +518,7 @@ type ContainerPortInfo struct {
 	Protocol      v1.Protocol
 }
 
-func GetPodInfo(clientset *kubernetes.Clientset, namespace string) ([]PodInfo, error) {
+func GetPodInfo(clientset kubernetes.Interface, namespace string) ([]PodInfo, error) {
 	pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, err

--- a/backend/pkg/k8s/scanner_test.go
+++ b/backend/pkg/k8s/scanner_test.go
@@ -1,0 +1,189 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestHasDefaultDenyAllPolicy(t *testing.T) {
+    // Test case 1: Default deny all policy exists
+    policyWithDefaultDeny := netv1.NetworkPolicy{
+        Spec: netv1.NetworkPolicySpec{},
+    }
+    if !hasDefaultDenyAllPolicy([]netv1.NetworkPolicy{policyWithDefaultDeny}) {
+        t.Errorf("Expected to identify default deny all policy, but it was not detected")
+    }
+
+    // Test case 2: No default deny all policy
+    policyWithoutDefaultDeny := netv1.NetworkPolicy{
+        Spec: netv1.NetworkPolicySpec{
+            Ingress: []netv1.NetworkPolicyIngressRule{
+                {},
+            },
+            Egress: []netv1.NetworkPolicyEgressRule{
+                {},
+            },
+        },
+    }
+    if hasDefaultDenyAllPolicy([]netv1.NetworkPolicy{policyWithoutDefaultDeny}) {
+        t.Errorf("Expected not to identify default deny all policy, but it was detected")
+    }
+}
+
+func TestIsDefaultDenyAllPolicy(t *testing.T) {
+	// Test case 1: Default deny all policy
+	defaultDenyPolicy := netv1.NetworkPolicy{
+		Spec: netv1.NetworkPolicySpec{},
+	}
+	if !isDefaultDenyAllPolicy(defaultDenyPolicy) {
+		t.Fatalf("Expected policy to be default deny all, but it was not")
+	}
+
+	// Test case 2: Non-default deny all policy
+	nonDefaultDenyPolicy := netv1.NetworkPolicy{
+		Spec: netv1.NetworkPolicySpec{
+			Ingress: []netv1.NetworkPolicyIngressRule{
+				{},
+			},
+			Egress: []netv1.NetworkPolicyEgressRule{
+				{},
+			},
+		},
+	}
+	if isDefaultDenyAllPolicy(nonDefaultDenyPolicy) {
+		t.Fatalf("Expected policy not to be default deny all, but it was")
+	}
+}
+
+func TestIsSystemNamespace(t *testing.T) {
+	// Test case 1: System namespace
+	systemNamespaces := []string{"kube-system", "tigera-operator", "kube-public", "kube-node-lease", "gatekeeper-system", "calico-system"}
+	for _, ns := range systemNamespaces {
+		if !IsSystemNamespace(ns) {
+			t.Fatalf("Expected namespace %s to be a system namespace, but it was not", ns)
+		}
+	}
+
+	// Test case 2: Non-system namespace
+	nonSystemNamespace := "test-namespace"
+	if IsSystemNamespace(nonSystemNamespace) {
+		t.Fatalf("Expected namespace %s not to be a system namespace, but it was", nonSystemNamespace)
+	}
+}
+
+func TestCalculateScore(t *testing.T) {
+	// Test case 1: All conditions met, maximum score expected
+	score1 := CalculateScore(true, true, 0)
+	if score1 != 42 {
+		t.Fatalf("Expected score to be 42, got %d", score1)
+	}
+
+	// Test case 2: No policies, no deny all, 5 unprotected pods
+	score2 := CalculateScore(false, false, 5)
+	if score2 != 17 {
+		t.Fatalf("Expected score to be 17, got %d", score2)
+	}
+
+	// Test case 3: No policies, no deny all, no unprotected pods
+	score3 := CalculateScore(false, false, 0)
+	if score3 != 22 {
+		t.Fatalf("Expected score to be 1, got %d", score3)
+	}
+
+	// Test case 4: Policies exist, deny all exists, no unprotected pods
+	score4 := CalculateScore(true, true, 0)
+	if score4 != 42 {
+		t.Fatalf("Expected score to be 42, got %d", score4)
+	}
+}
+
+func TestGetPodInfo(t *testing.T) {
+    var clientset kubernetes.Interface = fake.NewSimpleClientset()
+
+    podInfo := PodInfo{
+        Name: "test-pod",
+        Namespace: "test-namespace",
+        Labels: map[string]string{
+            "app": "test", // Label on pod to match netpol selector
+        },
+        Ports: []corev1.ContainerPort{
+            {
+                ContainerPort: 80,
+            },
+        },
+    }
+	
+    pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podInfo.Name,
+			Namespace: podInfo.Namespace,
+			Labels:    podInfo.Labels,
+		},
+        Spec: corev1.PodSpec{
+            Containers: []corev1.Container{
+                {
+                    Name:  "nginx",
+                    Image: "nginx",
+                    Ports: podInfo.Ports,
+                },
+            },
+        },
+	}
+    _, err := clientset.CoreV1().Pods("test-namespace").Create(context.TODO(), pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create pod: %v", err)
+	}
+
+	var expectedPodInfo []PodInfo
+	expectedPodInfo = append(expectedPodInfo, podInfo)
+
+    actualPodInfo, err := GetPodInfo(clientset, podInfo.Namespace)
+	if err != nil {
+		t.Fatalf("Failed to get actual podInfo: %v", err)
+	}
+
+    assert.Equal(t, expectedPodInfo, actualPodInfo, "they should be equal")
+}
+
+func TestYAMLToNetworkPolicy(t *testing.T) {
+	YAMLString := `
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-policy
+  namespace: test-namespace
+spec:
+  podSelector:
+    matchLabels:
+      app: test
+`
+	expectedNetworkPolicy := &netv1.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "networking.k8s.io/v1",
+			Kind:       "NetworkPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-policy",
+			Namespace: "test-namespace",
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
+	}
+
+	actualNetworkPolicy, err := YAMLToNetworkPolicy(YAMLString)
+	if err != nil {
+		t.Fatalf("Failed to convert YAML string to a NetworkPolicy object: %v", err)
+	}
+
+	assert.Equal(t, expectedNetworkPolicy, actualNetworkPolicy, "they should be equal")
+}

--- a/backend/pkg/k8s/visualizer.go
+++ b/backend/pkg/k8s/visualizer.go
@@ -26,7 +26,7 @@ type PolicyVisualization struct {
 }
 
 // gatherVisualizationData retrieves network policies and associated pods for visualization.
-func gatherVisualizationData(clientset *kubernetes.Clientset, namespace string) (*VisualizationData, error) {
+func gatherVisualizationData(clientset kubernetes.Interface, namespace string) (*VisualizationData, error) {
 	// Retrieve all network policies in the specified namespace
 	policies, err := clientset.NetworkingV1().NetworkPolicies(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {

--- a/backend/pkg/k8s/visualizer.go
+++ b/backend/pkg/k8s/visualizer.go
@@ -169,7 +169,8 @@ func HandlePolicyYAMLRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Retrieve the network policy YAML
-	yaml, err := getNetworkPolicyYAML(namespace, policyName)
+	clientset, err := GetClientset()
+	yaml, err := getNetworkPolicyYAML(clientset, namespace, policyName)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -180,12 +181,7 @@ func HandlePolicyYAMLRequest(w http.ResponseWriter, r *http.Request) {
 }
 
 // getNetworkPolicyYAML retrieves the YAML representation of a network policy, excluding annotations.
-func getNetworkPolicyYAML(namespace, policyName string) (string, error) {
-	clientset, err := GetClientset()
-	if err != nil {
-		return "", err
-	}
-
+func getNetworkPolicyYAML(clientset kubernetes.Interface, namespace string, policyName string) (string, error) {
 	// Get the specified network policy
 	networkPolicy, err := clientset.NetworkingV1().NetworkPolicies(namespace).Get(context.TODO(), policyName, metav1.GetOptions{})
 	if err != nil {

--- a/backend/pkg/k8s/visualizer_test.go
+++ b/backend/pkg/k8s/visualizer_test.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
 )
 
 type Metadata struct {
@@ -84,6 +84,23 @@ func TestGatherVisualizationData(t *testing.T) {
 func TestGetNetworkPolicyYAML(t *testing.T) {
 	var clientset kubernetes.Interface = fake.NewSimpleClientset()
 
+	var ns string = "test-namespace"
+
+	// Creating a pod object and a networkPolicy object
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod",
+			Namespace: ns,
+			Labels: map[string]string{
+				"app": "test", // Label on pod to match netpol selector
+			},
+		},
+	}
+	_, err := clientset.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create pod: %v", err)
+	}
+
 	testPolicy := &netv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-policy",
@@ -95,10 +112,9 @@ func TestGetNetworkPolicyYAML(t *testing.T) {
 			},
 		},
 	}
-
-	_, err := clientset.NetworkingV1().NetworkPolicies("test-namespace").Create(context.TODO(), testPolicy, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Failed to create test network policy: %v", err)
+	_, err1 := clientset.NetworkingV1().NetworkPolicies(ns).Create(context.TODO(), testPolicy, metav1.CreateOptions{})
+	if err1 != nil {
+		t.Fatalf("Failed to create test network policy: %v", err1)
 	}
 
 	// Call the getNetworkPolicyYAML function with the fake clientset
@@ -131,16 +147,149 @@ func TestGetNetworkPolicyYAML(t *testing.T) {
 	}
 
 	var expectedPolicy Policy
-	err1 := yaml.Unmarshal(expectedPolicyBytes, &expectedPolicy)
-	if err1 != nil {
-		t.Fatalf("error: %v", err1)
-	}
-
-	var actualPolicy Policy
-	err2 := yaml.Unmarshal([]byte(YAML), &actualPolicy)
+	err2 := yaml.Unmarshal(expectedPolicyBytes, &expectedPolicy)
 	if err2 != nil {
 		t.Fatalf("error: %v", err2)
 	}
 
+	var actualPolicy Policy
+	err3 := yaml.Unmarshal([]byte(YAML), &actualPolicy)
+	if err3 != nil {
+		t.Fatalf("error: %v", err3)
+	}
+
 	assert.Equal(t, expectedPolicy, actualPolicy, "they should be equal")
+}
+
+func TestGatherNamespacesWithPolicies(t *testing.T) {
+	// Define namespaces both with and without network policies
+	namespaces := []string{"test-namespace1", "test-namespace2", "test-namespace3", "test-namespace4"}
+	namespacesWithPolicies := []string{"test-namespace3", "test-namespace4"}
+
+	var clientset kubernetes.Interface = fake.NewSimpleClientset()
+
+	for _, ns := range namespaces {
+		// Create a namespace
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ns,
+			},
+		}
+		
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create namespace %s: %v", ns, err)
+		}
+	}
+
+	for _, ns := range namespacesWithPolicies {
+		// Create a pod in the namespace
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-pod",
+				Namespace: ns,
+				Labels: map[string]string{
+					"app": "test",
+				},
+			},
+		}
+		_, err := clientset.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create pod: %v", err)
+		}
+
+		// Create a networkPolicy in the namespace
+		networkPolicy := &netv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-policy",
+				Namespace: ns,
+			},
+			Spec: netv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "test"},
+				},
+			},
+		}
+		_, err1 := clientset.NetworkingV1().NetworkPolicies(ns).Create(context.TODO(), networkPolicy, metav1.CreateOptions{})
+		if err1 != nil {
+			t.Fatalf("Failed to create network policy in namespace %s: %v", ns, err1)
+		}
+	}
+
+	gatheredNamespaces, err := GatherNamespacesWithPolicies(clientset)
+	if err != nil {
+		t.Fatalf("Error calling GatherNamespacesWithPolicies: %v", err)
+	}
+
+	assert.Equal(t, namespacesWithPolicies, gatheredNamespaces, "they should be equal")
+}
+
+func TestGatherClusterVisualizationData(t *testing.T) {
+    namespacesWithPolicies := []string{"namespace1", "namespace2"}
+    expectedVisualizationData := make([]VisualizationData, len(namespacesWithPolicies))
+
+	var clientset kubernetes.Interface = fake.NewSimpleClientset()
+
+    for i, ns := range namespacesWithPolicies {
+		// Create a namespace
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ns,
+			},
+		}
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create namespace %s: %v", ns, err)
+		}
+
+		// Create a pod in the namespace
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-pod",
+				Namespace: ns,
+				Labels: map[string]string{
+					"app": "test",
+				},
+			},
+		}
+		_, err1 := clientset.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+		if err1 != nil {
+			t.Fatalf("Failed to create pod: %v", err1)
+		}
+
+        // Create a network policy in the namespace
+        networkPolicy := &netv1.NetworkPolicy{
+            ObjectMeta: metav1.ObjectMeta{
+				Name: "test-policy",
+				Namespace: ns,
+			},
+			Spec: netv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "test"},
+				},
+			},
+        }
+        _, err2 := clientset.NetworkingV1().NetworkPolicies(ns).Create(context.TODO(), networkPolicy, metav1.CreateOptions{})
+        if err2 != nil {
+            t.Fatalf("Failed to create network policy in namespace %s: %v", ns, err2)
+        }
+
+        vizData := &VisualizationData{
+            Policies: []PolicyVisualization{
+                {
+                    Name:       networkPolicy.Name,
+                    Namespace:  ns,
+					TargetPods: []string{"test-pod"}, 
+                },
+            },
+        }
+        expectedVisualizationData[i] = *vizData
+    }
+
+    gatheredVisualizationData, err := GatherClusterVisualizationData(clientset)
+    if err != nil {
+        t.Fatalf("Error calling GatherClusterVisualizationData: %v", err)
+    }
+
+    assert.Equal(t, expectedVisualizationData, gatheredVisualizationData)
 }

--- a/backend/pkg/k8s/visualizer_test.go
+++ b/backend/pkg/k8s/visualizer_test.go
@@ -2,15 +2,33 @@ package k8s
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
 )
+
+type Metadata struct {
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
+}
+
+type PodSelector struct {
+	MatchLabels map[string]string `yaml:"matchLabels"`
+}
+
+type Policy struct {
+	Metadata    Metadata    `yaml:"metadata"`
+	Spec        struct {
+		PodSelector PodSelector `yaml:"podSelector"`
+	} `yaml:"spec"`
+}
 
 func TestGatherVisualizationData(t *testing.T) {
 	var clientset kubernetes.Interface = fake.NewSimpleClientset()
@@ -59,7 +77,70 @@ func TestGatherVisualizationData(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(visualizationData, expected) {
-		t.Errorf("Visualization data mismatch. Expected: %v, Got: %v", expected, visualizationData)
+
+	assert.Equal(t, expected, visualizationData, "they should be equal")
+}
+
+func TestGetNetworkPolicyYAML(t *testing.T) {
+	var clientset kubernetes.Interface = fake.NewSimpleClientset()
+
+	testPolicy := &netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-policy",
+			Namespace: "test-namespace",
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
 	}
+
+	_, err := clientset.NetworkingV1().NetworkPolicies("test-namespace").Create(context.TODO(), testPolicy, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create test network policy: %v", err)
+	}
+
+	// Call the getNetworkPolicyYAML function with the fake clientset
+	YAML, err := getNetworkPolicyYAML(clientset, "test-namespace", "test-policy")
+	if err != nil {
+		t.Fatalf("Failed to get network policy YAML: %v", err)
+	}
+
+	// Policy YAML string
+	// expectedYAML := `
+	// metadata:
+	//   name: test-policy
+	//   namespace: test-namespace
+	// spec:
+	//   podSelector:
+	//     matchLabels:
+	// 	  app: test
+	// `
+
+	// Below the testPolicy which is expected is converted into Policy struct (map to bytes array to struct) and
+	// compared with actualPolicy which is also converted to Policy struct from string.
+	expectedNetworkPolicyMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(testPolicy)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	expectedPolicyBytes, err := yaml.Marshal(expectedNetworkPolicyMap)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	var expectedPolicy Policy
+	err1 := yaml.Unmarshal(expectedPolicyBytes, &expectedPolicy)
+	if err1 != nil {
+		t.Fatalf("error: %v", err1)
+	}
+
+	var actualPolicy Policy
+	err2 := yaml.Unmarshal([]byte(YAML), &actualPolicy)
+	if err2 != nil {
+		t.Fatalf("error: %v", err2)
+	}
+
+	assert.Equal(t, expectedPolicy, actualPolicy, "they should be equal")
 }

--- a/backend/pkg/k8s/visualizer_test.go
+++ b/backend/pkg/k8s/visualizer_test.go
@@ -1,0 +1,63 @@
+package k8s
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes"
+)
+
+func TestGatherVisualizationData(t *testing.T) {
+	var clientset kubernetes.Clientset
+	clientset = fake.NewSimpleClientset()
+
+	// Creating a pod object and a networkPolicy object
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod", 
+			Namespace: "test-namespace",
+		},
+	}
+	networkPolicy := &netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-policy", 
+			Namespace: "test-namespace",
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
+	}
+	_, err := clientset.CoreV1().Pods("test-namespace").Create(context.TODO(), pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create pod: %v", err)
+	}
+	_, erro := clientset.NetworkingV1().NetworkPolicies("test-namespace").Create(context.TODO(), networkPolicy, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create network policy: %v", erro)
+	}
+
+	visualizationData, err := gatherVisualizationData(&clientset, "test-namespace")
+	if err != nil {
+		t.Fatalf("Error occurred while gathering visualization data: %v", err)
+	}
+
+	expected := &VisualizationData{
+		Policies: []PolicyVisualization{
+			{
+				Name:       "test-policy",
+				Namespace:  "test-namespace",
+				TargetPods: []string{"test-pod"},
+			},
+		},
+	}
+	if !reflect.DeepEqual(visualizationData, expected) {
+		t.Errorf("Visualization data mismatch. Expected: %v, Got: %v", expected, visualizationData)
+	}
+}

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,13 +1,13 @@
+cloud.google.com/go/compute/metadata v0.2.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
-github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
+golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,5 +1,6 @@
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
@@ -7,5 +8,6 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=


### PR DESCRIPTION
Added tests for the below functions in 

**visualizer.go**:
- gatherVisualizationData
- getNetworkPolicyYAML
- GatherClusterVisualizationData
- GatherNamespacesWithPolicies

**scanner.go**:
- hasDefaultDenyAllPolicy
- isDefaultDenyAllPolicy
- IsSystemNamespace
- CalculateScore
- GetPodInfo
- YAMLToNetworkPolicy

**cilium-scanner.go**:
- MatchesLabels
- ConvertEndpointToSelector
- IsDefaultDenyAllCiliumClusterwidePolicy
- IsEmptyOrOnlyContainsEmptyObjects
- isEndpointSelectorEmpty
- IsDefaultDenyAllCiliumPolicy

Fixes #46 