### PR TITLE
Add OIDC auth provider

### DIFF
--- a/backend/pkg/k8s/scanner.go
+++ b/backend/pkg/k8s/scanner.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"


### PR DESCRIPTION
...really, all known ones, but IIRC OIDC is the only one thus far.

This will address errors of the form:

    no Auth Provider found for name "oidc"