### PR TITLE
chore: refactor cli help message

### DIFF
--- a/backend/cmd/root.go
+++ b/backend/cmd/root.go
@@ -13,20 +13,9 @@ var rootCmd = &cobra.Command{
 	Use:   "netfetch",
 	Short: "Netfetch is a CLI tool for scanning Kubernetes clusters for network policies",
 	Long: `Netfetch is a CLI tool that scans Kubernetes clusters for network policies
-	and evaluates them against best practices. It helps in ensuring that your
-	cluster's network configurations adhere to security standards.
-
-	Usage:
-	netfetch [command]
-
-	Available Commands:
-	scan        	Scan Kubernetes namespaces for network policies
-	scan namespace	Scan specific namespace in cluster
-	dash        	Open interactive dashboard
-	help        	Help about any command
-
-	Flags:
-	-h, --help   help for netfetch`,
+and evaluates them against best practices. It helps in ensuring that your
+cluster's network configurations adhere to security standards.
+`,
 }
 
 var versionCmd = &cobra.Command{


### PR DESCRIPTION
Hey,

First of all thanks for building such a good project. When I installed the netfetch and ran the help command I saw that the usage help message is duplicated as cobra generates it itself by default and this PR aims to refactor it.

Current version of the netfetch help message:

```
➜  netfetch git:(main) ✗ netfetch --help
Netfetch is a CLI tool that scans Kubernetes clusters for network policies
	and evaluates them against best practices. It helps in ensuring that your
	cluster's network configurations adhere to security standards.

	Usage:
	netfetch [command]

	Available Commands:
	scan        	Scan Kubernetes namespaces for network policies
	scan namespace	Scan specific namespace in cluster
	dash        	Open interactive dashboard
	help        	Help about any command

	Flags:
	-h, --help   help for netfetch

Usage:
  netfetch [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  dash        Launch the Netfetch interactive dashboard
  help        Help about any command
  scan        Scan Kubernetes namespaces for network policies
  version     Print the version number of Netfetch

Flags:
  -h, --help   help for netfetch

Use "netfetch [command] --help" for more information about a command.
``` 

Updated version:

```
➜  netfetch git:(main) ✗ go run backend/main.go --help
Netfetch is a CLI tool that scans Kubernetes clusters for network policies
and evaluates them against best practices. It helps in ensuring that your
cluster's network configurations adhere to security standards.

Usage:
  netfetch [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  dash        Launch the Netfetch interactive dashboard
  help        Help about any command
  scan        Scan Kubernetes namespaces for network policies
  version     Print the version number of Netfetch

Flags:
  -h, --help   help for netfetch

Use "netfetch [command] --help" for more information about a command.
```